### PR TITLE
updates to CircularList

### DIFF
--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -112,7 +112,7 @@ class Buffer {
   /// [Terminal.viewHeight].
   BufferLine getViewLine(int index) {
     index = index.clamp(0, terminal.viewHeight - 1);
-    return lines[convertViewLineToRawLine(index)]!;
+    return lines[convertViewLineToRawLine(index)];
   }
 
   BufferLine get currentLine {
@@ -171,7 +171,7 @@ class Buffer {
     for (var i = height - terminal.viewHeight; i < height; i++) {
       final y = i - scrollOffsetFromBottom;
       if (y >= 0 && y < height) {
-        result.add(lines[y]!);
+        result.add(lines[y]);
       }
     }
 

--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -449,10 +449,10 @@ class Buffer {
     if (!isInScrollableRegion) {
       final index = convertViewLineToRawLine(_cursorX);
       final newLine = _newEmptyLine();
-      lines.splice(index, 0, [newLine]);
+      lines.insert(index, newLine);
     } else {
       final newLine = _newEmptyLine();
-      lines.splice(_cursorY, 0, [newLine]);
+      lines.insert(_cursorY, newLine);
     }
   }
 
@@ -475,7 +475,7 @@ class Buffer {
       return;
     }
 
-    lines.splice(index, 1, []);
+    lines.remove(index);
   }
 
   void resize(int newWidth, int newHeight) {

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -449,7 +449,7 @@ class Terminal with Observable {
         break;
       }
 
-      final line = buffer.lines[row]!;
+      final line = buffer.lines[row];
 
       var xStart = 0;
       var xEnd = viewWidth - 1;

--- a/lib/utli/circular_list.dart
+++ b/lib/utli/circular_list.dart
@@ -59,7 +59,7 @@ class CircularList<T> {
   }
 
   T operator [](int index) {
-    if (index > length - 1) {
+    if (index >= length) {
       throw RangeError.range(index, 0, length - 1);
     }
 
@@ -67,7 +67,7 @@ class CircularList<T> {
   }
 
   operator []=(int index, T value) {
-    if (index > length - 1) {
+    if (index >= length) {
       throw RangeError.range(index, 0, length - 1);
     }
 

--- a/lib/utli/circular_list.dart
+++ b/lib/utli/circular_list.dart
@@ -97,25 +97,44 @@ class CircularList<T> {
     return _array[_getCyclicIndex(_length-- - 1)]!;
   }
 
-  /// Deletes and/or inserts items at a particular index (in that order).
-  void splice(int start, int deleteCount, List<T> items) {
-    // delete items
-    if (deleteCount > 0) {
-      for (int i = start; i < _length - deleteCount; i++)
-        _array[_getCyclicIndex(i)] = _array[_getCyclicIndex(i + deleteCount)];
-      length -= deleteCount;
+  /// Deletes item at [index].
+  void remove(int index, [int count = 1]) {
+    if (count > 0) {
+      for (var i = index; i < _length - count; i++) {
+        _array[_getCyclicIndex(i)] = _array[_getCyclicIndex(i + count)];
+      }
+      length -= count;
     }
-    if (items.length != 0) {
-      // add items
-      for (int i = _length - 1; i >= start; i--)
-        _array[_getCyclicIndex(i + items.length)] = _array[_getCyclicIndex(i)];
-      for (int i = 0; i < items.length; i++)
-        _array[_getCyclicIndex(start + i)] = items[i];
+  }
+
+  /// Inserts [item] at [index].
+  void insert(int index, T item) {
+    for (var i = _length - 1; i >= index; i--) {
+      _array[_getCyclicIndex(i + 1)] = _array[_getCyclicIndex(i)];
     }
 
-    // Adjust length as needed
+    _array[_getCyclicIndex(index)] = item;
+
+    if (_length + 1 > _array.length) {
+      _startIndex += 1;
+      onTrimmed?.call(1);
+    } else {
+      _length++;
+    }
+  }
+
+  /// Inserts [items] at [index] in order.
+  void insertAll(int index, List<T> items) {
+    for (var i = _length - 1; i >= index; i--) {
+      _array[_getCyclicIndex(i + 1)] = _array[_getCyclicIndex(i)];
+    }
+
+    for (var i = 0; i < items.length; i++) {
+      _array[_getCyclicIndex(index + i)] = items[i];
+    }
+
     if (_length + items.length > _array.length) {
-      int countToTrim = _length + items.length - _array.length;
+      final countToTrim = _length + items.length - _array.length;
       _startIndex += countToTrim;
       length = _array.length;
       onTrimmed?.call(countToTrim);

--- a/lib/utli/circular_list.dart
+++ b/lib/utli/circular_list.dart
@@ -27,9 +27,10 @@ class CircularList<T> {
     // Reconstruct array, starting at index 0. Only transfer values from the
     // indexes 0 to length.
     final newArray = List<T?>.generate(
-        value,
-        (index) =>
-            index < _array.length ? _array[_getCyclicIndex(index)] : null);
+      value,
+      (index) => index < _array.length ? _array[_getCyclicIndex(index)] : null,
+    );
+
     _startIndex = 0;
     _array = newArray;
   }
@@ -47,8 +48,10 @@ class CircularList<T> {
     _length = value;
   }
 
-  void forEach(void Function(T? item, int index) callback,
-      [bool includeBuffer = false]) {
+  void forEach(
+    void Function(T? item, int index) callback, [
+    bool includeBuffer = false,
+  ]) {
     final len = includeBuffer ? _array.length : _length;
     for (int i = 0; i < len; i++) {
       callback(_array[_getCyclicIndex(i)], i);

--- a/lib/utli/circular_list.dart
+++ b/lib/utli/circular_list.dart
@@ -58,11 +58,19 @@ class CircularList<T> {
     }
   }
 
-  T? operator [](int index) {
-    return _array[_getCyclicIndex(index)];
+  T operator [](int index) {
+    if (index > length - 1) {
+      throw RangeError.range(index, 0, length - 1);
+    }
+
+    return _array[_getCyclicIndex(index)]!;
   }
 
-  operator []=(int index, T? value) {
+  operator []=(int index, T value) {
+    if (index > length - 1) {
+      throw RangeError.range(index, 0, length - 1);
+    }
+
     _array[_getCyclicIndex(index)] = value;
   }
 


### PR DESCRIPTION
Range check has been added to `[]` operator to prevent hidden bugs. And `CircularList.splice` is splitted into three methods: `remove`, `insert` and `insertAll` to avoid unnecessary creation of List objects (e.g. [newLine] ), and improve readability.